### PR TITLE
Update for game patch 1.1.0 and change to only activate in Exploration age

### DIFF
--- a/treasure-lens.modinfo
+++ b/treasure-lens.modinfo
@@ -1,19 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Mod id="treasure-lens" version="1" xmlns="ModInfo">
+<Mod id="treasure-lens" version="1.1.0" xmlns="ModInfo">
     <Properties>
         <Name>LOC_MOD_TREASURE_LENS_NAME</Name>
         <Description>LOC_MOD_TREASURE_LENS_DESCRIPTION</Description>
         <Authors>adamk33n3r</Authors>
         <Package>Mod</Package>
         <AffectsSavedGames>0</AffectsSavedGames>
+        <Version>1.1.0</Version>
     </Properties>
     <Dependencies>
         <Mod id="base-standard" title="LOC_MODULE_BASE_STANDARD_NAME" />
-        <Mod id="age-exploration" title="LOC_MODULE_AGE_EXPLORATION_NAME" />
     </Dependencies>
-    <ActionCriteria></ActionCriteria>
+    <ActionCriteria>
+        <Criteria id="age-exploration">
+			<AgeInUse>AGE_EXPLORATION</AgeInUse>
+        </Criteria>
+    </ActionCriteria>
     <ActionGroups>
-        <ActionGroup id="game-treasure-lens" scope="game" criteria="exploration-age-current">
+        <ActionGroup id="game-treasure-lens" scope="game" criteria="age-exploration">
             <Actions>
                 <UIScripts>
                     <Item>ui/lenses/layer/treasure-layer.js</Item>

--- a/ui/decorators/panel-mini-map.js
+++ b/ui/decorators/panel-mini-map.js
@@ -1,6 +1,6 @@
 import { LENS_ID } from '../../globals.js';
 
-class PanelMiniMapDecorator {
+class LensPanelDecorator {
     constructor(minimap) {
         this.minimap = minimap;
     }
@@ -18,4 +18,4 @@ class PanelMiniMapDecorator {
     onAttributeChanged(name, oldValue, newValue) {}
 }
 
-Controls.decorate('panel-mini-map', (minimap) => new PanelMiniMapDecorator(minimap));
+Controls.decorate('lens-panel', (minimap) => new LensPanelDecorator(minimap));


### PR DESCRIPTION
Updated this for game patch 1.1.0, where they changed the class. Also changed the ActionCriteria to only activate the mod during Exploration age. Bumped the mods version number to 1.1.0.